### PR TITLE
Escape html characters like <>, support lists for a paragraph

### DIFF
--- a/CliOutput.Test/HelpTestsHtml.cs
+++ b/CliOutput.Test/HelpTestsHtml.cs
@@ -19,7 +19,7 @@ public class HelpTestsHtml
 
         var result = writer.GetBuffer();
         result.Should()
-            .Be("<h2>Description</h2><br/><p>&nbsp;&nbsp;World</p>");
+            .Be("<h2>Description</h2><p>&nbsp;&nbsp;World</p>");
     }
 
     [Fact]
@@ -34,7 +34,7 @@ public class HelpTestsHtml
 
         var result = writer.GetBuffer();
         result.Should()
-            .Be("<h2>Usage</h2><br/><p>&nbsp;&nbsp;Hello</p>");
+            .Be("<h2>Usage</h2><p>&nbsp;&nbsp;Hello</p>");
     }
 
     [Fact]
@@ -53,7 +53,7 @@ public class HelpTestsHtml
 
         var result = writer.GetBuffer();
         result.Should()
-            .Be("<h2>Usage</h2><br/><p>&nbsp;&nbsp;Hello [command]</p>");
+            .Be("<h2>Usage</h2><p>&nbsp;&nbsp;Hello [command]</p>");
     }
 
     [Fact]
@@ -72,7 +72,7 @@ public class HelpTestsHtml
 
         var result = writer.GetBuffer();
         result.Should()
-            .Be("<h2>Usage</h2><br/><p>&nbsp;&nbsp;Hello Welcome Brrr</p>");
+            .Be("<h2>Usage</h2><p>&nbsp;&nbsp;Hello Welcome Brrr</p>");
     }
 
     [Fact]
@@ -89,7 +89,7 @@ public class HelpTestsHtml
 
         var result = writer.GetBuffer();
         result.Should()
-            .Be("<h2>Usage</h2><br/><p>&nbsp;&nbsp;Hello <MORNING><EVENING></p>");
+            .Be("<h2>Usage</h2><p>&nbsp;&nbsp;Hello &lt;MORNING&gt;&lt;EVENING&gt;</p>");
     }
 
     [Fact]
@@ -106,7 +106,7 @@ public class HelpTestsHtml
 
         var result = writer.GetBuffer();
         result.Should()
-            .Be("<h2>Usage</h2><br/><p>&nbsp;&nbsp;Hello [options]</p>");
+            .Be("<h2>Usage</h2><p>&nbsp;&nbsp;Hello [options]</p>");
     }
 
     [Fact]
@@ -124,7 +124,7 @@ public class HelpTestsHtml
         var result = writer.GetBuffer();
         // TODO: More fully test this output, possibly via Approvals testing
         result.Should()
-            .StartWith("<h2>Arguments</h2><br/><table><tr><td>");
+            .StartWith("<h2>Arguments</h2><table><tr><td>Morning");
     }
 
     [Fact]
@@ -138,11 +138,12 @@ public class HelpTestsHtml
         var writer = new Html(new OutputContext(true));
 
         writer.Write(arguments);
+        writer.Write(arguments);
 
         var result = writer.GetBuffer();
         // TODO: More fully test this output, possibly via Approvals testing
         result.Should()
-            .StartWith("<h2>Arguments</h2><br/><table><tr><td>");
+            .StartWith("<h2>Arguments</h2><table><tr><td>EarlyEvening");
     }
 
     [Fact]
@@ -160,7 +161,7 @@ public class HelpTestsHtml
         var result = writer.GetBuffer();
         // TODO: More fully test this output, possibly via Approvals testing
         result.Should()
-            .StartWith($"<h2>Options</h2><br/><table><tr><td>");
+            .StartWith($"<h2>Options</h2><table><tr><td>Morning");
     }
 
     [Fact]
@@ -178,7 +179,7 @@ public class HelpTestsHtml
         var result = writer.GetBuffer();
         // TODO: More fully test this output, possibly via Approvals testing
         result.Should()
-            .StartWith($"<h2>Subcommands</h2><br/><table><tr><td>");
+            .StartWith($"<h2>Subcommands</h2><table><tr><td>Morning");
     }
 
     [Fact]
@@ -199,6 +200,6 @@ public class HelpTestsHtml
         var result = writer.GetBuffer();
         // TODO: More fully test this output, possibly via Approvals testing
         result.Should()
-            .StartWith($"<h2>Description</h2><br/>");
+            .StartWith($"<h2>Description</h2>");
     }
 }

--- a/CliOutput.Test/HtmlTests.cs
+++ b/CliOutput.Test/HtmlTests.cs
@@ -109,7 +109,7 @@ public class HtmlTests
 
         var result = writer.GetBuffer();
         result.Should()
-            .Be($"<h2>Goodnight moon</h2><br/><p>&nbsp;&nbsp;Hello world</p><p>&nbsp;&nbsp;See you later</p>");
+            .Be($"<h2>Goodnight moon</h2><p>&nbsp;&nbsp;Hello world</p><p>&nbsp;&nbsp;See you later</p>");
     }
 
     [Fact]
@@ -138,11 +138,11 @@ public class HtmlTests
     [InlineData(ParagraphAppearance.Heading5, "<h5>Hello world</h5>")]
     [InlineData(ParagraphAppearance.Heading6, "<h6>Hello world</h6>")]
     [InlineData(ParagraphAppearance.BlockQuote, "<blockquote>Hello world</blockquote>")]
-    [InlineData(ParagraphAppearance.BlockQuoteDoubled, "<blockquote>Hello world</blockquote>")]
-    [InlineData(ParagraphAppearance.BlockQuoteTripled, "<blockquote>Hello world</blockquote>")]
-    //[InlineData(ParagraphAppearance.NumberedList, "<p>Hello world</p>")]
-    //[InlineData(ParagraphAppearance.BulletedList, "<p>Hello world</p>")]
-    //[InlineData(ParagraphAppearance.DefinitionList, "#Hello world")]
+    //[InlineData(ParagraphAppearance.BlockQuoteDoubled, "<blockquote><blockquote>Hello world</blockquote></blockquote>")]
+    //[InlineData(ParagraphAppearance.BlockQuoteTripled, "<blockquote><blockquote><blockquote>Hello world</blockquote></blockquote></blockquote>")]
+    [InlineData(ParagraphAppearance.NumberedList, "<ol><li>Hello world</li></ol>")]
+    [InlineData(ParagraphAppearance.BulletedList, "<ul><li>Hello world</li></ul>")]
+    //[InlineData(ParagraphAppearance.DefinitionList, "#Hello world")] This needs more complex structure
     //[InlineData(ParagraphAppearance.TaskItemUnchecked, "[ ] Hello world")]
     //[InlineData(ParagraphAppearance.TaskItemChecked, "[x] Hello world")]
     public void Outputs_Paragraph_with_style(string? appearance, string expected)


### PR DESCRIPTION
- Escape html characters like `<>`
- Support list appearance for a paragraph